### PR TITLE
Managed databases in Camunda BPM chart

### DIFF
--- a/charts/camunda-bpm-platform/.gitignore
+++ b/charts/camunda-bpm-platform/.gitignore
@@ -1,0 +1,2 @@
+charts/*.tgz
+Chart.lock

--- a/charts/camunda-bpm-platform/.helmignore
+++ b/charts/camunda-bpm-platform/.helmignore
@@ -21,6 +21,3 @@
 .idea/
 *.tmproj
 .vscode/
-
-charts/*.tgz
-Chart.lock

--- a/charts/camunda-bpm-platform/.helmignore
+++ b/charts/camunda-bpm-platform/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+charts/*.tgz
+Chart.lock

--- a/charts/camunda-bpm-platform/Chart.yaml
+++ b/charts/camunda-bpm-platform/Chart.yaml
@@ -21,3 +21,17 @@ sources:
   - https://github.com/camunda/camunda-bpm-platform
 maintainers:
   - name: Ahmed AbouZaid
+
+
+dependencies:
+  - name: postgresql
+    version: 10.4.8
+    repository: "@bitnami"
+    tags:
+      - managed-postgresql
+
+  - name: mysql
+    version: 8.5.10
+    repository: "@bitnami"
+    tags:
+      - managed-mysql

--- a/charts/camunda-bpm-platform/Chart.yaml
+++ b/charts/camunda-bpm-platform/Chart.yaml
@@ -26,12 +26,12 @@ maintainers:
 dependencies:
   - name: postgresql
     version: 10.4.8
-    repository: "@bitnami"
+    repository: "https://charts.bitnami.com/bitnami"
     tags:
       - managed-postgresql
 
   - name: mysql
     version: 8.5.10
-    repository: "@bitnami"
+    repository: "https://charts.bitnami.com/bitnami"
     tags:
       - managed-mysql

--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -31,16 +31,16 @@ Camunda BPM has 2 options in terms of databases.
 
 #### Internal database
 
-The H2 database is used by default which works fine if you just want to test Camunda BPM Platform.
+The H2 database is used by default which works fine if you just want to test the Camunda BPM Platform.
 But since the database is embedded, only 1 deployment replica could be used.
 
 #### External database
 
 Databases like PostgreSQL or MySQL could be used also which is the same as in production.
 
-You have the option to use a managed instanse of whether PostgreSQL or MySQL in your Camunda BPM installation.
+You have the option to use a managed instance of whether PostgreSQL or MySQL in your Camunda BPM installation.
 
-The chart integrates with corresponding subcharts which installs appropriate databases. The boolean variables `tags.managed-postgresql` and `tags.managed-mysql` gives you the option to choose the RDMS you prefer. By default, neither databases are installed.
+The chart integrates with corresponding subcharts which installs appropriate databases. The boolean variables `tags.managed-postgresql` and `tags.managed-mysql` gives you the option to choose the RDMS you prefer. By default, neither database is installed.
 
 ```shell
 # postgresql + camunda
@@ -50,11 +50,11 @@ helm install camunda camunda-bpm-platform --set tags.managed-postgresql=true
 helm install camunda camunda-bpm-platform --set tags.managed-mysql=true
 ```
 
-The chart parameters will align according to the chosen managed database, e.g. driver, connection URL and auth data. Also, the special secret will be created to store authentication info for Camunda BPM to access the DB.
+The chart parameters will align according to the chosen managed database, e.g. driver, connection URL, and auth data. Also, the special secret will be created to store authentication info for Camunda BPM to access the DB.
 
-> Warning: deployments of Camunda BPM and PostgreSQL/MySQL are not syncronized. Therefore, Camunda BPM can fails several times until the RDMS is becomes ready.
+> Warning: deployments of Camunda BPM and PostgreSQL/MySQL are not synchronized. Therefore, Camunda BPM can fail several times until the RDMS becomes ready.
 
-> Warning: you have an option to use only one managed DB. You cannot combine woth `tags.managed-postgresql` and `tags.managed-mysql` . If you do so, the chart installation will fail due to values constrains:
+> Warning: you have an option to use only one managed DB. You cannot combine woth `tags.managed-postgresql` and `tags.managed-mysql` . If you do so, the chart installation will fail due to values constraints:
 
 ```shell
 # will fail
@@ -62,7 +62,7 @@ helm install camunda camunda-bpm-platform --set tags.managed-postgresql=true,tag
 
 ```
 
-Otherwise, you may use an external database, but without an managed database. In this case, do not specify `tags.managed-*` paramenters and you should create the secret by yourself.
+Otherwise, you may use an external database, but without a managed database. In this case, do not specify `tags.managed-*` parameters and you should create the secret by yourself.
 
 Here is an example to use PostgreSQL as an external database, without any managed installation.
 

--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -54,7 +54,7 @@ database:
     enabled: false
   external:
     enabled: true
-    credentialsSecertName: camunda-bpm-platform-postgresql-credentials
+    credentialsSecretName: camunda-bpm-platform-postgresql-credentials
     driver: "org.postgresql.Driver"
     url: "jdbc:postgresql://cambpm-demo-db:5432/process-engine"
 ```

--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -20,22 +20,51 @@ $ helm install demo camunda/camunda-bpm-platform
 
 ### Image
 
-Camunda BPM open-source Docker image comes in 3 distributions `tomcat`, `wildfly`, and `run`.
+Camunda BPM open-source Docker image comes in 3 distributions `tomcat` , `wildfly` , and `run` .
 Each distro has different tags, check the list of [supported tags/releases](https://github.com/camunda/docker-camunda-bpm-platform#supported-tagsreleases) by the docker project for more details.
 
-The image used in the chart is `latest` (which's actually `tomcat-latest`).
+The image used in the chart is `latest` (which's actually `tomcat-latest` ).
 
 ### Database
 
 Camunda BPM has 2 options in terms of databases.
 
 #### Internal database
+
 The H2 database is used by default which works fine if you just want to test Camunda BPM Platform.
 But since the database is embedded, only 1 deployment replica could be used.
 
 #### External database
+
 Databases like PostgreSQL or MySQL could be used also which is the same as in production.
-Here is an example to use PostgreSQL as an external database.
+
+You have the option to use a managed instanse of whether PostgreSQL or MySQL in your Camunda BPM installation.
+
+The chart integrates with corresponding subcharts which installs appropriate databases. The boolean variables `tags.managed-postgresql` and `tags.managed-mysql` gives you the option to choose the RDMS you prefer. By default, neither databases are installed.
+
+```shell
+# postgresql + camunda
+helm install camunda camunda-bpm-platform --set tags.managed-postgresql=true
+
+# mysql + camunda
+helm install camunda camunda-bpm-platform --set tags.managed-mysql=true
+```
+
+The chart parameters will align according to the chosen managed database, e.g. driver, connection URL and auth data. Also, the special secret will be created to store authentication info for Camunda BPM to access the DB.
+
+> Warning: deployments of Camunda BPM and PostgreSQL/MySQL are not syncronized. Therefore, Camunda BPM can fails several times until the RDMS is becomes ready.
+
+> Warning: you have an option to use only one managed DB. You cannot combine woth `tags.managed-postgresql` and `tags.managed-mysql` . If you do so, the chart installation will fail due to values constrains:
+
+```shell
+# will fail
+helm install camunda camunda-bpm-platform --set tags.managed-postgresql=true,tags.managed.mysql=true
+
+```
+
+Otherwise, you may use an external database, but without an managed database. In this case, do not specify `tags.managed-*` paramenters and you should create the secret by yourself.
+
+Here is an example to use PostgreSQL as an external database, without any managed installation.
 
 First, create the secret that has the database credentials.
 
@@ -58,8 +87,6 @@ database:
     driver: "org.postgresql.Driver"
     url: "jdbc:postgresql://cambpm-demo-db:5432/process-engine"
 ```
-
-**Please note**, this Helm chart doesn't manage any external database, it just uses what's configured.
 
 ### Metrics
 

--- a/charts/camunda-bpm-platform/templates/_helpers.tpl
+++ b/charts/camunda-bpm-platform/templates/_helpers.tpl
@@ -102,7 +102,7 @@ Connection string for external database if used managed DB
         {{- if index .Values.tags "managed-postgresql" -}}
             {{- printf "org.postgresql.Driver"  -}}
         {{- else if index .Values.tags "managed-mysql" -}}
-            {{- printf "com.mysql.jdbc.Driver"  -}}
+            {{- printf "com.mysql.cj.jdbc.Driver"  -}}
         {{- end -}}
 
     {{- end -}}

--- a/charts/camunda-bpm-platform/templates/_helpers.tpl
+++ b/charts/camunda-bpm-platform/templates/_helpers.tpl
@@ -83,7 +83,7 @@ Connection string for external database if used managed DB
         
         {{- if index .Values.tags "managed-postgresql" -}}
 
-            {{- printf "jdbc:postgresql://%s-postgresql:%d/%s" .Release.Name  (.Values.postgresql.postgresPort | int )  .Values.postgresql.postgresDatabase  -}}
+            {{- printf "jdbc:postgresql://%s-postgresql:%d/%s" .Release.Name  (.Values.postgresql.postgresqlPort | int )  .Values.postgresql.postgresqlDatabase  -}}
             
         {{- else if index .Values.tags "managed-mysql" -}}
 

--- a/charts/camunda-bpm-platform/templates/_helpers.tpl
+++ b/charts/camunda-bpm-platform/templates/_helpers.tpl
@@ -60,3 +60,50 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+
+{{/*
+The name for secret to create in which the authentication data for DB connection is stored
+*/}}
+{{- define "camunda-bpm-platform.database.external.credentialsSecretName" -}}
+
+{{- default .Values.database.external.credentialsSecretName (include "camunda-bpm-platform.name" . )}}-external-credentials
+{{- end }}
+
+
+
+{{/*
+Connection string for external database if used managed DB
+*/}}
+{{- define "camunda-bpm-platform.database.external.url" -}}
+
+    {{- if .Values.database.external.enabled -}}
+
+        
+        {{- if index .Values.tags "managed-postgresql" -}}
+
+            {{- printf "jdbc:postgresql://%s-postgresql:%d/%s" .Release.Name  (.Values.postgresql.postgresPort | int )  .Values.postgresql.postgresDatabase  -}}
+            
+        {{- else if index .Values.tags "managed-mysql" -}}
+
+            {{- printf "jdbc:mysql://%s-mysql:%d/%s" .Release.Name  (.Values.mysql.port | int )  .Values.mysql.auth.database  -}}
+        
+        {{- end -}}
+
+    {{- end -}}
+{{- end -}}
+
+{{/* Driver to connect to external DB */}}
+{{- define "camunda-bpm-platform.database.external.driver" -}}
+
+    {{- if .Values.database.external.enabled -}}
+        
+        {{- if index .Values.tags "managed-postgresql" -}}
+            {{- printf "org.postgresql.Driver"  -}}
+        {{- else if index .Values.tags "managed-mysql" -}}
+            {{- printf "com.mysql.jdbc.Driver"  -}}
+        {{- end -}}
+
+    {{- end -}}
+{{- end -}}

--- a/charts/camunda-bpm-platform/templates/constrains.tpl
+++ b/charts/camunda-bpm-platform/templates/constrains.tpl
@@ -30,8 +30,8 @@ Fail in case internal database is enabled and replicaCount is more than "1".
 {{/*
 Should use either PostgreSQL or MySQL connection driver
 */}}
-{{- if not (or (eq .Values.database.external.driver "org.postgresql.Driver")  (eq .Values.database.external.driver "com.mysql.jdbc.Driver") ) -}}
-{{ fail "Unrecognized connection driver, use either 'org.postgresql.Driver' or `com.mysql.jdbc.Driver`."}}
+{{- if not (or (eq .Values.database.external.driver "org.postgresql.Driver")  (eq .Values.database.external.driver "com.mysql.cj.jdbc.Driver") ) -}}
+{{ fail "Unrecognized connection driver, use either 'org.postgresql.Driver' or `com.mysql.cj.jdbc.Driver`."}}
 {{- end }}
 
 {{/* 

--- a/charts/camunda-bpm-platform/templates/constrains.tpl
+++ b/charts/camunda-bpm-platform/templates/constrains.tpl
@@ -26,3 +26,19 @@ Fail in case internal database is enabled and replicaCount is more than "1".
     {{ fail "Deployment replicaCount cannot be more than 1 in case internal database is used."}}
 {{- end }}
 {{- end }}
+
+{{/*
+Should use either PostgreSQL or MySQL connection driver
+*/}}
+{{- if not (or (eq .Values.database.external.driver "org.postgresql.Driver")  (eq .Values.database.external.driver "com.mysql.jdbc.Driver") ) -}}
+{{ fail "Unrecognized connection driver, use either 'org.postgresql.Driver' or `com.mysql.jdbc.Driver`."}}
+{{- end }}
+
+{{/* 
+Only one managed database can be used
+*/}}
+
+{{- if and (index .Values.tags "managed-postgresql") (index .Values.tags "managed-mysql") -}}
+
+{{ fail "Please choose only one managed database: either Postgres or MySQL, not both" }}
+{{- end -}}

--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -35,23 +35,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DEBUG
-              value: "{{ .Values.general.debug }}"
+              value: {{ .Values.general.debug | quote }}
             - name: JMX_PROMETHEUS
-              value: "{{ .Values.metrics.enabled }}"
+              value: {{ .Values.metrics.enabled | quote }}
             {{- if .Values.database.external.enabled }}
             - name: DB_DRIVER
-              value: "{{ .Values.database.external.driver }}"
+              value:  {{ default .Values.database.external.driver (include "camunda-bpm-platform.database.external.driver" . ) | quote }}
             - name: DB_URL
-              value: "{{ .Values.database.external.url }}"
+              value: {{ include "camunda-bpm-platform.database.external.url" . | default .Values.database.external.url | quote }}
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.external.credentialsSecertName }}
+                  name: {{ .Values.database.external.credentialsSecretName }}
                   key: DB_USERNAME
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.external.credentialsSecertName }}
+                  name: {{ .Values.database.external.credentialsSecretName }}
                   key: DB_PASSWORD
             {{- end }}
           ports:

--- a/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
+++ b/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.database.external.enabled}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.database.external.credentialsSecretName }}
+  labels:
+    {{- include "camunda-bpm-platform.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if index .Values.tags "managed-postgresql" }}
+  DB_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
+  DB_USERNAME: {{ .Values.postgresql.postgresqlUsername | b64enc }}
+  
+  {{- else if index .Values.tags "managed-mysql" }}
+
+  DB_PASSWORD: {{ .Values.mysql.auth.username | b64enc }}
+  DB_USERNAME: {{ .Values.mysql.auth.password | b64enc }}
+
+  {{- else }}
+  DB_PASSWORD: foo
+  DB_USERNAME: bar
+  {{- end }}
+
+{{- end }}

--- a/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
+++ b/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.database.external.enabled}}
+{{- if  and ( .Values.database.external.enabled) ( or ( index .Values.tags "managed-postgresql" ) ( index .Values.tags "managed-mysql" ) ) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
+++ b/charts/camunda-bpm-platform/templates/external-db-cred-secret.yaml
@@ -13,8 +13,8 @@ data:
   
   {{- else if index .Values.tags "managed-mysql" }}
 
-  DB_PASSWORD: {{ .Values.mysql.auth.username | b64enc }}
-  DB_USERNAME: {{ .Values.mysql.auth.password | b64enc }}
+  DB_PASSWORD: {{ .Values.mysql.auth.password | b64enc}}
+  DB_USERNAME: {{ .Values.mysql.auth.username | b64enc }}
 
   {{- else }}
   DB_PASSWORD: foo

--- a/charts/camunda-bpm-platform/templates/tests/db-connection.yaml
+++ b/charts/camunda-bpm-platform/templates/tests/db-connection.yaml
@@ -1,0 +1,54 @@
+{{- if and (.Values.database.external.enabled) (or (index .Values.tags "managed-postgresql") (index .Values.tags "managed-mysql")) -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "camunda-bpm-platform.fullname" . }}-db-connection"
+  labels:
+    {{- include "camunda-bpm-platform.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    {{- if index .Values.tags "managed-postgresql" }}
+    - name: psql
+      image: postgres:12
+      command: ['pg_isready']     
+      args: [
+          "--host", "{{ .Release.Name }}-postgresql",
+          "--port", "{{ .Values.postgresql.postgresqlPort }}",
+          "--dbname", {{ .Values.postgresql.postgresqlDatabase | quote }}
+          "--timeout", "60"
+      ]
+      env:
+      # https://stackoverflow.com/questions/6405127/how-do-i-specify-a-password-to-psql-non-interactively/6405296
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.credentialsSecretName }}
+              key: "DB_PASSWORD"
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.credentialsSecretName }}
+              key: "DB_USERNAME"        
+    {{- end }}
+    {{- if index .Values.tags "managed-mysql" }}
+    - name: mysql
+      image: bitnami/mysql:8.0.25-debian-10-r16
+      command: ['/bin/bash', "-c"]     
+      args:
+          - |
+            password_aux="${MYSQL_ROOT_PASSWORD:-}"
+            if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+            fi
+            mysqladmin -uroot -p"${password_aux}" -h {{ .Release.Name }}-mysql -P {{ .Values.mysql.port }} --wait=60 status
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-mysql
+              key: "mysql-root-password"      
+    {{- end }}  
+  restartPolicy: Never
+{{- end }}

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
+
 general:
   debug: false
   replicaCount: 1
@@ -17,14 +26,39 @@ image:
 database:
   # In case H2 database is used.
   internal:
-    enabled: true
+    enabled: false
     diskSize: 1G
   # In case PostgreSQL or MySQL databases are used.
   external:
-    enabled: false
-    credentialsSecertName: ""
-    driver: ""
-    url: ""
+    enabled: true
+    credentialsSecretName: camunda-bpm-platform-credentials
+    driver: org.postgresql.Driver
+    url: jdbc:postgresql://camunda-bpm-postgresql:5432/postgres
+
+postgresql:
+  postgresqlUsername: postgres
+  postgresqlPassword: postgres
+  postgresDatabase: camunda
+  postgresPort: 5432
+
+  persistence:
+    enabled: true
+
+mysql:
+  auth:
+    database: camunda
+    username: mysql
+    password: mysql
+    rootPassword: mysql
+  port: 3306
+
+  primary:
+    persistence:
+      enabled: true
+
+tags:
+  managed-postgresql: false
+  managed-mysql: true
 
 service:
   type: ClusterIP
@@ -53,7 +87,8 @@ serviceAccount:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -66,10 +101,12 @@ ingress:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -77,7 +114,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # If you do want to specify resources, uncomment the following lines,
   # adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -26,21 +26,21 @@ image:
 database:
   # In case H2 database is used.
   internal:
-    enabled: false
+    enabled: true
     diskSize: 1G
   # In case PostgreSQL or MySQL databases are used.
   external:
-    enabled: true
+    enabled: false
     credentialsSecretName: camunda-bpm-platform-credentials
     driver: org.postgresql.Driver
     url: jdbc:postgresql://camunda-bpm-postgresql:5432/postgres
 
 # parameters will be also used by subchart @bitnami/postgresql
 postgresql:
-  postgresqlUsername: postgres
-  postgresqlPassword: postgres
-  postgresDatabase: camunda
-  postgresPort: 5432
+  postgresqlUsername: camunda-user
+  postgresqlPassword: camunda
+  postgresqlDatabase: camunda
+  postgresqlPort: 5432
 
   # define if you create a PVC for the PostgreSQL database
   persistence:
@@ -49,9 +49,10 @@ postgresql:
 # parameters will be also used by subchart @bitnami/mysql
 mysql:
   auth:
+    username: camunda-user
+    password: camunda
     database: camunda
-    username: mysql
-    password: mysql
+    # you should alter this parameter on bootstrap
     rootPassword: mysql
   port: 3306
 

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -44,7 +44,7 @@ postgresql:
 
   # define if you create a PVC for the PostgreSQL database
   persistence:
-    enabled: true
+    enabled: false
 
 # parameters will be also used by subchart @bitnami/mysql
 mysql:
@@ -59,11 +59,11 @@ mysql:
   # define if you create a PVC for the MySQL database
   primary:
     persistence:
-      enabled: true
+      enabled: false
 
 tags:
   managed-postgresql: false
-  managed-mysql: true
+  managed-mysql: false
 
 service:
   type: ClusterIP

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -35,15 +35,18 @@ database:
     driver: org.postgresql.Driver
     url: jdbc:postgresql://camunda-bpm-postgresql:5432/postgres
 
+# parameters will be also used by subchart @bitnami/postgresql
 postgresql:
   postgresqlUsername: postgres
   postgresqlPassword: postgres
   postgresDatabase: camunda
   postgresPort: 5432
 
+  # define if you create a PVC for the PostgreSQL database
   persistence:
     enabled: true
 
+# parameters will be also used by subchart @bitnami/mysql
 mysql:
   auth:
     database: camunda
@@ -52,6 +55,7 @@ mysql:
     rootPassword: mysql
   port: 3306
 
+  # define if you create a PVC for the MySQL database
   primary:
     persistence:
       enabled: true


### PR DESCRIPTION
I suggest providing users the opportunity to bootstrap an RDMS instance for their Camunda BPM installation. 

During installation, an user may specify either `tags.managed-postgresql=true` or tags.managed-mysql=true` to install a subchart (but not to use them both). For PostgreSQL it may use **bitnami/postgresql** and for MySQL the **bitnami/mysql** charts accordingly:


With postgres:
```shell
helm install camunda-with-managed-db camunda-bpm-platform --set tags.managed-postgres=true
```

Output:

```shell

-> % kubectl get all -l app.kubernetes.io/instance=camunda-with-managed-db
NAME                                                                READY   STATUS    RESTARTS   AGE
pod/camunda-with-managed-db-camunda-bpm-platform-58587cb6ff-j6s5m   1/1     Running   3          5m51s
pod/camunda-with-managed-db-mysql-0                                 1/1     Running   0          5m50s

NAME                                                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/camunda-with-managed-db-camunda-bpm-platform   ClusterIP   10.105.94.252   <none>        8080/TCP   5m51s
service/camunda-with-managed-db-mysql                  ClusterIP   10.102.218.18   <none>        3306/TCP   5m51s
service/camunda-with-managed-db-mysql-headless         ClusterIP   None            <none>        3306/TCP   5m51s

NAME                                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/camunda-with-managed-db-camunda-bpm-platform   1/1     1            1           5m51s

NAME                                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/camunda-with-managed-db-camunda-bpm-platform-58587cb6ff   1         1         1       5m51s

NAME                                             READY   AGE
statefulset.apps/camunda-with-managed-db-mysql   1/1     5m51s

```

With MySQL:

```shell
helm install camunda-with-managed-db camunda-bpm-platform --set tags.managed-mysql=true
```

Output:

```shell
-> kubectl get all -l app.kubernetes.io/instance=camunda-with-managed-db                                                                                                                                             
NAME                                                                READY   STATUS    RESTARTS   AGE
pod/camunda-with-managed-db-camunda-bpm-platform-5668b78d4d-f5wj6   1/1     Running   3          2m13s
pod/camunda-with-managed-db-mysql-0                                 1/1     Running   0          2m13s

NAME                                                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/camunda-with-managed-db-camunda-bpm-platform   ClusterIP   10.105.201.228   <none>        8080/TCP   2m13s
service/camunda-with-managed-db-mysql                  ClusterIP   10.105.207.167   <none>        3306/TCP   2m13s
service/camunda-with-managed-db-mysql-headless         ClusterIP   None             <none>        3306/TCP   2m13s

NAME                                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/camunda-with-managed-db-camunda-bpm-platform   1/1     1            1           2m13s

NAME                                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/camunda-with-managed-db-camunda-bpm-platform-5668b78d4d   1         1         1       2m13s

NAME                                             READY   AGE
statefulset.apps/camunda-with-managed-db-mysql   1/1     2m13s

```


Due to the fact, that the feature uses already existing charts, we may benefit from others' contributions. In the case of managed databases, it is possible to alter their parameters (persistence, HA, replication, and so on).


> Warning: the persistence mode is not enabled for managed database by default. This is due to ambiguity when a DB was created, but the user tries to do `helm upgrade` with new DB user\pass - neither managed DB will updates the already initialized database.

