### PR TITLE
Add ".Values.extraEnvs" to Deployment and set default .extraEnvs to {}

### DIFF
--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+          {{- if .Values.extraEnvs }}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          {{- end }}
             - name: DEBUG
               value: "{{ .Values.general.debug }}"
             - name: JMX_PROMETHEUS

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -16,6 +16,10 @@ image:
   command: []
   args: []
 
+# Config camunda by some environment variable  for database, tz
+# See more https://github.com/camunda/docker-camunda-bpm-platform/blob/next/README.md
+extraEnvs: {}
+
 # By default H2 database is used, which is handy for demos and tests,
 # however, H2 is not supported in a clustered scenario.
 # So for real-world workloads, an external database like PostgreSQL should be used.


### PR DESCRIPTION
Hi Camunda Team !

I have a issue when deploy and run camunda.  It's here

https://forum.camunda.org/t/your-driver-may-not-support-getautocommit-or-setautocommit/16469/9

and solution are set testOnBorrow="true" . It's can be done with set DB_VALIDATE_ON_BORROW=true to container. And i was added extraEnvs to can be to customize more config over Container Environment, please merge my commit .

Many Thank !