### PR TITLE
Added startup probe

### DIFF
--- a/charts/camunda-bpm-platform/ci/custom-values.yaml
+++ b/charts/camunda-bpm-platform/ci/custom-values.yaml
@@ -6,3 +6,12 @@ initContainers:
 extraEnvs:
 - name: DB_VALIDATE_ON_BORROW
   value: "false"
+
+startupProbe:
+  enabled: false
+  config:
+    httpGet:
+      path: /camunda/
+      port: http
+    initialDelaySeconds: 120
+    periodSeconds: 60

--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -75,13 +75,17 @@ spec:
               containerPort: {{ .Values.metrics.service.port }}
               protocol: TCP
             {{- end }}
-          {{ if .Values.livenessProbe.enabled -}}
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe.config | nindent 12 }}
+          {{ if .Values.startupProbe.enabled -}}
+          readinessProbe:
+            {{- toYaml .Values.startupProbe.config | nindent 12 }}
           {{- end }}
           {{ if .Values.readinessProbe.enabled -}}
           readinessProbe:
             {{- toYaml .Values.readinessProbe.config | nindent 12 }}
+          {{- end }}
+          {{ if .Values.livenessProbe.enabled -}}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe.config | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -62,8 +62,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# An arbitrary use of livenessProbe could make a lot of service interruption, use it wisely.
-livenessProbe:
+# The StartupProbe works with Kubernetes >= 1.6
+startupProbe:
   enabled: false
   config:
     httpGet:
@@ -74,6 +74,16 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
+  config:
+    httpGet:
+      path: /camunda/
+      port: http
+    initialDelaySeconds: 120
+    periodSeconds: 60
+
+# An arbitrary use of livenessProbe could make a lot of service interruption, use it wisely.
+livenessProbe:
+  enabled: false
   config:
     httpGet:
       path: /camunda/


### PR DESCRIPTION
Added [StartupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) which allows waiting for a slow start.