### PR TITLE
workflows: use release notes in chart-releaser

### DIFF
--- a/.github/config/chart-releaser.yaml
+++ b/.github/config/chart-releaser.yaml
@@ -1,0 +1,1 @@
+release-notes-file: RELEASE-NOTES.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,25 @@ env:
   HELM_VERSION: 3.4.0
 
 jobs:
-  update-charts-changelog:
+  find-charts-to-release:
+    runs-on: ubuntu-latest
+    outputs:
+      modified-charts-files: ${{ steps.list-changed-charts.outputs.all_modified_files }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get list of changed charts
+        id: list-changed-charts
+        uses: tj-actions/changed-files@v1.1.3
+        with:
+          files: charts/*/Chart.yaml
+
+  generate-charts-changelog:
+    needs: find-charts-to-release
+    if: needs.find-charts-to-release.outputs.modified-charts-files
     runs-on: ubuntu-latest
     container: quay.io/git-chglog/git-chglog:0.15.0
     steps:
@@ -19,30 +37,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Bash is needed by "tj-actions/changed-files" Github action.
-      - name: Install dependencies
+      - name: Install main dependencies
         run: |
           apk add bash
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Get list of changed charts
-        id: list-changed-charts
-        uses: tj-actions/changed-files@v1.1.3
-        with:
-          files: charts/*/Chart.yaml
-
-      - name: Update charts changelog
-        if: steps.list-changed-charts.outputs.any_changed == 'true'
+      - name: Generate charts changelog files
         shell: bash
         run: |
           set -x
           apk add git grep yq
 
-          for chart_file in ${{ steps.list-changed-charts.outputs.all_modified_files }}; do
+          # TODO: Bundle all of that logic in a Github Action to make it easy to share.
+          for chart_file in ${{ needs.find-charts-to-release.outputs.modified-charts-files }}; do
               chart_name=$(grep -Po "(?<=^name: ).+" ${chart_file})
               chart_version=$(grep -Po "(?<=^version: ).+" ${chart_file})
               chart_tag="${chart_name}-${chart_version}"
@@ -54,25 +60,29 @@ jobs:
                   --output "${chart_path}/CHANGELOG.md" \
                   --tag-filter-pattern "${chart_name}"  \
                   --next-tag "${chart_tag}"             \
-                  --path "${chart_path}"                \
+                  --path "${chart_path}"
 
               #
-              # Generate ArtifactHub annotation and update Chart.yaml with it.
+              # Generate RELEASE-NOTES.md file (used for Github release notes and ArtifactHub "changes" annotation).
               git-chglog                                    \
-                  --output "${chart_path}/release-notes.md" \
+                  --output "${chart_path}/RELEASE-NOTES.md" \
                   --tag-filter-pattern "${chart_name}"      \
                   --next-tag "${chart_tag}"                 \
                   --path "${chart_path}" "${chart_tag}"
 
+              #
+              # Update ArtifactHub "changes" annotation in the Chart.yaml file.
+              # https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
+              change_types="Added Changed Deprecated Removed Fixed Security"
+
               # TODO: Rethink about this approach of using bash to generate YAML changes for ArtifactHub,
               # and find out if there is a better/cleaner way to make it.
-              commit_types="Added Changed Deprecated Removed Fixed Security"
               echo '|' > "${chart_path}/changes-for-artifacthub.yaml"
-              for commit_type in ${commit_types}; do
-                  commit_type_section=$(sed -rn "/^\#+\s${commit_type}/,/^$/p" "${chart_path}/release-notes.md")
-                  if [[ -n "${commit_type_section}" ]]; then
-                      echo "${commit_type_section}" | egrep '^-' | sed 's/^- //g' | while read commit_message; do
-                          echo "  - kind: ${commit_type,,}"
+              for change_type in ${change_types}; do
+                  change_type_section=$(sed -rn "/^\#+\s${change_type}/,/^$/p" "${chart_path}/RELEASE-NOTES.md")
+                  if [[ -n "${change_type_section}" ]]; then
+                      echo "${change_type_section}" | egrep '^-' | sed 's/^- //g' | while read commit_message; do
+                          echo "  - kind: ${change_type,,}"
                           echo "    description: \"${commit_message}\""
                       done >> "${chart_path}/changes-for-artifacthub.yaml"
                   fi
@@ -87,15 +97,19 @@ jobs:
                   ${chart_path}/Chart-with-artifacthub-changes.yaml
 
               mv ${chart_path}/Chart-with-artifacthub-changes.yaml ${chart_path}/Chart.yaml
-
-              # Push changes to the main branch and current branch.
-              git add ${chart_path}/CHANGELOG.md ${chart_path}/Chart.yaml
-              git commit -m "Update changelog for chart ${chart_name} ${chart_version}"
-              git push origin "${GITHUB_REF##*/}":main "${GITHUB_REF##*/}"
           done
 
-  release:
-    needs: update-charts-changelog
+      - name: Stash generated charts changelog files
+        uses: actions/upload-artifact@v2
+        with:
+          name: charts-generated-changelog
+          path: |
+            charts/*/RELEASE-NOTES.md
+            charts/*/CHANGELOG.md
+            charts/*/Chart.yaml
+
+  release-charts:
+    needs: generate-charts-changelog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -103,10 +117,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Workaround because checkout action doesn't pull latest changes.
-      # https://github.com/actions/checkout/issues/439
-      - name: Update local checkout
-        run: git pull --no-rebase
+      - name: Unstash generated charts changelog files
+        uses: actions/download-artifact@v2
+        with:
+          name: charts-generated-changelog
+          path: charts
 
       - name: Configure Git
         run: |
@@ -119,55 +134,48 @@ jobs:
           version: "${{ env.HELM_VERSION }}"
 
       - name: Run Chart Releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        with:
+          version: v1.3.0
+          config: .github/config/chart-releaser.yaml
 
-      - name: Get Released Charts
-        id: get-released-charts
-        run: |
-          released_charts=$(find .cr-release-packages -name "*.tgz" -printf '%P ' | sed 's/\.tgz//g')
-          echo "released_charts: ${released_charts}"
-          echo "::set-output name=released_charts::${released_charts}"
-    outputs:
-      released_charts: ${{ steps.get-released-charts.outputs.released_charts }}
 
-  # A workaround till helm/chart-releaser supports release notes.
-  # https://github.com/helm/chart-releaser/issues/118
-  # https://github.com/helm/chart-releaser/pull/137
-  update-charts-release-notes:
-    needs: release
+  commit-charts-changelog:
+    needs:
+      - find-charts-to-release
+      - release-charts
     runs-on: ubuntu-latest
-    container: quay.io/git-chglog/git-chglog:0.15.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Publish charts release notes
+      - name: Unstash generated charts changelog files
+        uses: actions/download-artifact@v2
+        with:
+          name: charts-generated-changelog
+          path: charts
+
+      - name: Commit charts CHANGELOG.md file
         run: |
-          set -x
-          apk add git curl jq grep
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-          repo_api_base="https://api.github.com/repos/${GITHUB_REPOSITORY}"
-          released_charts="${{ needs.release.outputs.released_charts }}"
+          released_charts_files="${{ needs.find-charts-to-release.outputs.modified-charts-files }}"
+          echo "released_charts_files: ${released_charts_files}"
 
-          echo "released_charts: ${released_charts}"
+          # Commit changes locally.
+          for chart_file in ${released_charts_files}; do
+              chart_name=$(grep -Po "(?<=^name: ).+" ${chart_file})
+              chart_version=$(grep -Po "(?<=^version: ).+" ${chart_file})
+              chart_path="charts/${chart_name}"
 
-          for chart_tag in ${released_charts}; do
-              chart_version=$(echo ${chart_tag} | grep -oP '\d+\.\d+\.\d+')
-              chart_name=${chart_tag/-$chart_version/}
-
-              chart_tag_changelog=$(git-chglog --tag-filter-pattern ${chart_name} \
-                  --path charts/${chart_name} ${chart_tag})
-
-              chart_release_notes_json=$(jq -n --arg body "$chart_tag_changelog" '{body: $body}')
-
-              chart_latest_release_id=$(curl --silent -H "Accept: application/vnd.github.v3+json" \
-                  ${repo_api_base}/releases/tags/${chart_tag} | jq '.id')
-
-              curl -X PATCH -H "Accept: application/vnd.github.v3+json" \
-                  -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-                  ${repo_api_base}/releases/${chart_latest_release_id} -d "${chart_release_notes_json}"
+              git add ${chart_path}/CHANGELOG.md
+              git commit -m "Update CHANGELOG for chart ${chart_name} ${chart_version}"
           done
+
+          # Push changes to the main branch.          
+          git push origin "${GITHUB_REF##*/}":main

--- a/charts/camunda-bpm-platform/Chart.yaml
+++ b/charts/camunda-bpm-platform/Chart.yaml
@@ -33,7 +33,3 @@ annotations:
   # This will be generated automatically by the release workflow.
   # https://github.com/camunda-community-hub/camunda-helm/blob/main/.github/workflows/release.yaml
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added startup probe (disabled by default)"
-    - kind: added
-      description: "Added an option to set deployment initContainers"


### PR DESCRIPTION
The newest version of chart-releaser allows setting release notes file. So this PR use that feature and remove the workaround that was used before (it was updating the release note after the actual release by calling Github APIs).