### PR TITLE
feature: template extraEnvs with helm tpl function

### DIFF
--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -93,14 +93,14 @@ and an external database should be used if you want to increase the number of th
 #### Extra environment variables
 
 The deployment could be customized by providing extra environment variables according to the project
-[Docker image](https://github.com/camunda/docker-camunda-bpm-platform). The extra environment variables will be templated using the ['tpl' Function](https://helm.sh/docs/howto/charts_tips_and_tricks/). This allows camunda to get dynamic environment variables like service-Endpoints from a parent Helm-Chart.
+[Docker image](https://github.com/camunda/docker-camunda-bpm-platform). The extra environment variables will be templated using the ['tpl' function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function). This is useful to pass a template string as a value to a chart or render external configuration files.
 
 ```yaml
 extraEnvs:
 - name: DB_VALIDATE_ON_BORROW
   value: "false"
-- name: base_jee.client.soap.baseURL.processintegration
-  value: http://{{ .Release.Name }}-service-name:8080/path
+- name: SERVICE_PORT
+  value: {{ .Values.service.port }}
 ```
 
 #### Debugging

--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -93,12 +93,14 @@ and an external database should be used if you want to increase the number of th
 #### Extra environment variables
 
 The deployment could be customized by providing extra environment variables according to the project
-[Docker image](https://github.com/camunda/docker-camunda-bpm-platform).
+[Docker image](https://github.com/camunda/docker-camunda-bpm-platform). The extra environment variables will be templated using the ['tpl' Function](https://helm.sh/docs/howto/charts_tips_and_tricks/). This allows camunda to get dynamic environment variables like service-Endpoints from a parent Helm-Chart.
 
 ```yaml
 extraEnvs:
 - name: DB_VALIDATE_ON_BORROW
   value: "false"
+- name: base_jee.client.soap.baseURL.processintegration
+  value: http://{{ .Release.Name }}-service-name:8080/path
 ```
 
 #### Debugging

--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -64,7 +64,9 @@ spec:
                   name: {{ .Values.database.credentialsSecretName | default $fullName }}
                   key: {{ .Values.database.credentialsSecretKeys.password }}
           {{- if .Values.extraEnvs }}
-            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          {{- with tpl (toYaml .Values.extraEnvs) . }}
+            {{ . | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - name: {{ .Values.service.portName }}


### PR DESCRIPTION
The allows camunda to get dynamic envVars like a Release Name from parent Helm-Charts