### PR TITLE
Add service annotations

### DIFF
--- a/charts/camunda-bpm-platform/ci/custom-values.yaml
+++ b/charts/camunda-bpm-platform/ci/custom-values.yaml
@@ -24,3 +24,7 @@ startupProbe:
       port: http
     initialDelaySeconds: 120
     periodSeconds: 60
+
+service:
+  annotations:
+    dummy-key: dummy-val

--- a/charts/camunda-bpm-platform/templates/service.yaml
+++ b/charts/camunda-bpm-platform/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "camunda-bpm-platform.fullname" . }}
   labels:
     {{- include "camunda-bpm-platform.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -41,6 +41,7 @@ service:
   type: ClusterIP
   port: 8080
   portName: http
+  annotations: {}
 
 metrics:
   enabled: false


### PR DESCRIPTION
Allow to customize service annotations e.g. for the Ambassador Gateway.