### PR TITLE
Handle ingress api version automatically

### DIFF
--- a/charts/camunda-bpm-platform/templates/_helpers.tpl
+++ b/charts/camunda-bpm-platform/templates/_helpers.tpl
@@ -84,3 +84,18 @@ true
 false
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress according to Kubernetes version.
+*/}}
+{{- define "camunda-bpm-platform.ingress.apiVersion" -}}
+{{- if .Values.ingress.enabled -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/camunda-bpm-platform/templates/ingress.yaml
+++ b/charts/camunda-bpm-platform/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "camunda-bpm-platform.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ (include "camunda-bpm-platform.ingress.apiVersion" .) }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Handle ingress API version automatically.
Inspired by [Bitnami common template](https://github.com/bitnami/charts/blob/9548e2478970b4f53b4e0dcfaa5b144149f9b187/bitnami/common/templates/_capabilities.tpl#L74).

Fixes: #33