### PR TITLE
feat: handle extracontainers, tpl volumes and secret enabled

### DIFF
--- a/charts/camunda-bpm-platform/README.md
+++ b/charts/camunda-bpm-platform/README.md
@@ -50,6 +50,7 @@ database:
   driver: org.postgresql.Driver
   url: jdbc:postgresql://camunda-bpm-platform-postgresql:5432/process-engine
   credentialsSecretName: camunda-bpm-platform-postgresql-credentials
+  credentialsSecretEnabled: true
 
 service:
   type: ClusterIP
@@ -124,6 +125,22 @@ initContainers:
   command: ['sh', '-c', 'echo "The initContainers work as expected"']
 ```
 
+### Extra Containers
+
+For a reason or another, you could need to add sidecars.
+e.g. you could have a fluentd that check your logs or a vault that inject your db secrets.
+
+If that's needed, it could be done as the following:
+
+```yaml
+extraContainers:
+- name: fluentd
+  image: "fluentd"
+  volumeMounts:
+    - mountPath: /my_mounts/cribl-config
+      name: config-storage
+```
+
 ### Image
 
 Camunda BPM Platform open-source Docker image comes in 3 distributions `tomcat`, `wildfly`, and `run`.
@@ -162,6 +179,7 @@ database:
   driver: org.postgresql.Driver
   url: jdbc:postgresql://camunda-bpm-platform-postgresql:5432/process-engine
   credentialsSecretName: camunda-bpm-platform-postgresql-credentials
+  credentialsSecretEnabled: true
   # The username and password keys could be customized to whatever used in the credentials secret.
   credentialsSecretKeys:
     username: DB_USERNAME

--- a/charts/camunda-bpm-platform/ci/custom-values.yaml
+++ b/charts/camunda-bpm-platform/ci/custom-values.yaml
@@ -1,5 +1,10 @@
 recreatePods: true
 
+extraContainers:
+- name: sidecar-loop
+  image: busybox:1.28
+  command: ['sh', '-c', 'sleep 1h']
+
 initContainers:
 - name: pre-startup-checks
   image: busybox:1.28

--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- toYaml .Values.initContainers | nindent 6 }}
       {{- end }}
       containers:
+      {{- if .Values.extraContainers }}
+      {{- with tpl (toYaml .Values.extraContainers) . }}
+        {{ . | nindent 8 }}
+      {{- end }}
+      {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -63,6 +68,7 @@ spec:
               value: "{{ .Values.database.driver }}"
             - name: DB_URL
               value: "{{ .Values.database.url }}"
+            {{- if .Values.database.credentialsSecretEnabled }}
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -73,6 +79,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.credentialsSecretName | default $fullName }}
                   key: {{ .Values.database.credentialsSecretKeys.password }}
+            {{- end }}
           {{- if .Values.extraEnvs }}
           {{- with tpl (toYaml .Values.extraEnvs) . }}
             {{ . | nindent 12 }}
@@ -107,8 +114,8 @@ spec:
             - name: {{ $fullName }}-database-h2
               mountPath: /camunda/camunda-h2-dbs
             {{- end }}
-            {{- with .Values.extraVolumeMounts }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
           {{- end }}
       {{ if eq (include "camunda-bpm-platform.withVolumes" .) "true" -}}
@@ -118,8 +125,8 @@ spec:
           persistentVolumeClaim:
             claimName: {{ $fullName }}-database-h2
         {{- end -}}
-        {{- with .Values.extraVolumes }}
-          {{- toYaml . | nindent 8 }}
+        {{- if .Values.extraVolumes }}
+          {{- tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/camunda-bpm-platform/templates/secret.yaml
+++ b/charts/camunda-bpm-platform/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- $h2DatabaseIsUsed := eq (include "camunda-bpm-platform.h2DatabaseIsUsed" .) "true" -}}
 {{- $noCredentialsSecretIsProvided := (empty .Values.database.credentialsSecretName) -}}
-{{- if and $h2DatabaseIsUsed $noCredentialsSecretIsProvided -}}
+{{- if and $h2DatabaseIsUsed $noCredentialsSecretIsProvided .Values.database.credentialsSecretEnabled -}}
 # This secret is used for ephemeral H2 database only.
 # Create your own secret for external databases like PostgreSQL.
 apiVersion: v1

--- a/charts/camunda-bpm-platform/templates/service.yaml
+++ b/charts/camunda-bpm-platform/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,6 +26,7 @@ spec:
 
   selector:
     {{- include "camunda-bpm-platform.selectorLabels" . | nindent 4 }}
+{{- end }}
 ---
 {{- if .Values.metrics.enabled }}
 apiVersion: v1

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -29,18 +29,23 @@ extraEnvs: []
 # - name: DB_VALIDATE_ON_BORROW
 #   value: false
 
+# Extra containers to have sidecars
+extraContainers: []
+
 # By default H2 database is used, which is handy for demos and tests,
 # however, H2 is not supported in a clustered scenario.
 # So for real-world workloads, an external database like PostgreSQL should be used.
 database:
   driver: org.h2.Driver
   url: jdbc:h2:./camunda-h2-dbs/process-engine
+  credentialsSecretEnabled: true
   credentialsSecretName: ""
   credentialsSecretKeys:
     username: DB_USERNAME
     password: DB_PASSWORD
 
 service:
+  enabled: true
   annotations: {}
   port: 8080
   portName: http


### PR DESCRIPTION
Hello !
It’s a PR to manage:
- `extraContainers`, to have sidecars
- tpl on `extraVolumes` to use `$fullname` and more
- `credentialsSecretEnabled` to disable env from secret (when you have a vault you can't have k8s secret)
- `service.enabled` if you have a proxy sidecar for auth